### PR TITLE
Add open source link at the bottom of the main tool widget

### DIFF
--- a/src/sections/uniswap-v3-calculator/FullApp/index.tsx
+++ b/src/sections/uniswap-v3-calculator/FullApp/index.tsx
@@ -505,6 +505,16 @@ export function FullApp() {
             </p>
           </div>
         </a>
+        <div className="mt-8 text-center">
+          <a
+            href="https://github.com/0xMetacrypt/uniswap-v3-calculator-simulator"
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            This project is open source. View on GitHub.
+          </a>
+        </div>
         <div className="mx-4 mt-12">
           <div className="mx-auto max-w-4xl">
             <div className="flow-root">

--- a/src/sections/uniswap-v3-calculator/FullApp/index.tsx
+++ b/src/sections/uniswap-v3-calculator/FullApp/index.tsx
@@ -3,6 +3,7 @@
 import React, { FC, ReactNode, useEffect, useMemo, useState } from "react";
 
 import Slider from "@mui/material/Slider";
+import { FaGithub } from "react-icons/fa";
 import { MdOutlineCancel } from "react-icons/md";
 import { VscLoading } from "react-icons/vsc";
 
@@ -510,9 +511,12 @@ export function FullApp() {
             href="https://github.com/0xMetacrypt/uniswap-v3-calculator-simulator"
             target="_blank"
             rel="noreferrer"
-            className="text-blue-600 hover:underline"
+            className="text-center text-blue-600 hover:underline"
           >
-            This project is open source. View on GitHub.
+            <div className="flex items-center justify-center space-x-2">
+              <FaGithub />
+              <span>View on GitHub.</span>
+            </div>
           </a>
         </div>
         <div className="mx-4 mt-12">


### PR DESCRIPTION
Add a link at the bottom of the main tool widget to show that the project is open source.

* Add a link at the bottom of the main tool widget in `src/sections/uniswap-v3-calculator/FullApp/index.tsx`.
* Set the link text to "This project is open source. View on GitHub."
* Set the link URL to "https://github.com/0xMetacrypt/uniswap-v3-calculator-simulator".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/0xMetacrypt/uniswap-v3-calculator-simulator?shareId=ec2d5f5f-6674-49b0-9cde-b8ea9ca95a1d).